### PR TITLE
Changes to subsite install profile

### DIFF
--- a/odsherred_subsite.install
+++ b/odsherred_subsite.install
@@ -43,4 +43,110 @@ function odsherred_subsite_install() {
 
 }
 
+function odsherred_subsite_install_tasks($install_state) {
+  $tasks = array(
+    'odsherred_subsite_setup_after' => array(
+      'display_name' => st('Setup'),
+      'display' => FALSE,
+      'type' => 'normal'
+    ),
+  );
 
+  return $tasks;
+}
+
+function odsherred_subsite_setup_after() {
+  # From https://os2web.atlassian.net/browse/ODSDK-92
+  #1. ”Home” skal hedde ”Forside”
+  $home_menu_id = 368;
+
+  $item = menu_link_load($home_menu_id);
+  $item['link_title'] = 'Forside';
+
+  menu_link_save($item);
+
+  #2. ”Basic Page” skal hedde ”Simpel side”
+  $sql = "UPDATE node_type SET name = 'Simpel side' WHERE type = 'page'";
+  db_query($sql);
+
+  #3. ”node view” skal være aktiveret
+  // See 6/7
+
+  #4. Simple sider skal default IKKE være udgivet
+  // Removed all status, promoted and other options
+  variable_set('node_options_page', array());
+
+  #5. Når man ser siderne i Filtered HTML, skal den IKKE stå fortløbende
+
+  #6. Når jeg logger på som superbruger, skal brugerfladen layoutmæssigt være magen til den jeg har når jeg logger på som admin – både når jeg opretter en side og når jeg redigerer i den (og alt muligt andet, men det er det jeg lige kan se)
+  #7. Superbrugere skal kunne sætte sider i menu
+  $super_user_rid = 4;
+  user_role_grant_permissions($super_user_rid, array('view the administration theme', 'access overlay', 'administer menu'));
+
+  #8. Når man laver en kontaktboks, skal vejledningen omkring hvordan man skriver telefonnr. være rigtig!
+  // Fixed in features
+
+  #9. funtionerne ”a-å”, ”læs højt” og ”sitemap” også skal med på alle subsites.
+  // Copied from subsite_grundindstillinger.features.menu_links.inc
+  $menu_links['user-menu:a-aa-index'] = array(
+    'menu_name' => 'user-menu',
+    'link_path' => 'a-aa-index',
+    'router_path' => 'a-aa-index',
+    'link_title' => 'A-Å Indeks',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+    ),
+    'module' => 'menu',
+    'hidden' => '0',
+    'external' => '0',
+    'has_children' => '0',
+    'expanded' => '0',
+    'weight' => '0',
+  );
+  // Exported menu link: user-menu:http://www.adgangforalle.dk/
+  $menu_links['user-menu:http://www.adgangforalle.dk/'] = array(
+    'menu_name' => 'user-menu',
+    'link_path' => 'http://www.adgangforalle.dk/',
+    'router_path' => '',
+    'link_title' => 'Læs højt',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+    ),
+    'module' => 'menu',
+    'hidden' => '0',
+    'external' => '1',
+    'has_children' => '0',
+    'expanded' => '0',
+    'weight' => '0',
+  );
+  // Exported menu link: user-menu:sitemap
+  $menu_links['user-menu:sitemap'] = array(
+    'menu_name' => 'user-menu',
+    'link_path' => 'sitemap',
+    'router_path' => 'sitemap',
+    'link_title' => 'Sitemap',
+    'options' => array(
+      'attributes' => array(
+        'title' => '',
+      ),
+    ),
+    'module' => 'menu',
+    'hidden' => '0',
+    'external' => '0',
+    'has_children' => '0',
+    'expanded' => '0',
+    'weight' => '0',
+  );
+
+  foreach ($menu_links as $link) {
+    $exists = db_query("SELECT mlid from {menu_links} WHERE link_title=:link_title AND link_path=:link_path", array(':link_title' =>  $link['link_title'], ':link_path' => $link['link_path']))->fetchField();
+    // Save the record if the data does not exist
+    if (!$exists) {
+      menu_link_save($link);
+    }
+  }
+}

--- a/reroll.sh
+++ b/reroll.sh
@@ -71,14 +71,14 @@ if [ -d "build/$BUILD_DIR/modules" ]; then
 	(
 	cd $DRUPAL_ROOT
   echo "Updating database... Site will go in maintenance mode!"
-	mdrush.sh "vset maintenance_mode 1"
-	mdrush.sh "updatedb"
+#	mdrush.sh "vset maintenance_mode 1"
+#	mdrush.sh "updatedb"
 
 	# Finnally clear the cache
 	echo "Clearing cache..."
-	mdrush.sh "cc registry"
-	mdrush.sh "cc all"
-	mdrush.sh "vset maintenance_mode 0"
+#	mdrush.sh "cc registry"
+#	mdrush.sh "cc all"
+#	mdrush.sh "vset maintenance_mode 0"
   )
 
 	echo "Deploy Complete. End of maintenance mode!"


### PR DESCRIPTION
- Fixes ODSDK-92
- Temporary fix, should be fixed in features
- Changes made to reroll.sh in prod
- Added install task to fix issues:
  - Rename menu "Home" to "Forside"
  - Rename "Basic page" to "Simpel side"
  - Set default not published on "Simpel side"
  - Give "superbruger" permission to use admin theme, overlay and edit
    menu
  - Add menu items to user menu
